### PR TITLE
Reintroduce postgres support

### DIFF
--- a/wsgidav/dc/seahub_db.py
+++ b/wsgidav/dc/seahub_db.py
@@ -31,12 +31,27 @@ def create_seahub_db_engine():
     #import local_settings
     #db_infos = local_settings.DATABASES['default']
 
-    if db_infos.get('ENGINE') != 'django.db.backends.mysql':
-        _logger.warning('Failed to init seahub db, only mysql db supported.')
+    if db_infos.get('ENGINE') == 'django.db.backends.mysql':
+        db_type = "mysql"
+        pass
+    elif db_infos.get('ENGINE') == 'django.db.backends.postgresql_psycopg2':
+        db_type = "pgsql"
+        pass
+    elif db_infos.get('ENGINE') == 'django.db.backends.postgresql':
+        db_type = "pgsql"
+        pass
+    else:
+        _logger.warning('Failed to init seahub db, only mysql and postgres db supported.')
         return
-    
+
     db_host = db_infos.get('HOST', '127.0.0.1')
-    db_port = int(db_infos.get('PORT', '3306'))
+    if db_type == "mysql":
+        db_port = int(db_infos.get('PORT', '3306'))
+    elif db_type == "pgsql":
+        db_port = int(db_infos.get('PORT', '3306'))
+    else:
+        _logger.warning('Failed to init seahub db, only mysql and postgres db supported.')
+        return
     db_name = db_infos.get('NAME')
     if not db_name:
         _logger.warning ('Failed to init seahub db, db name is not set.')
@@ -47,7 +62,13 @@ def create_seahub_db_engine():
         return
     db_passwd = db_infos.get('PASSWORD')
 
-    db_url = "mysql+pymysql://%s:%s@%s:%s/%s?charset=utf8" % (db_user, quote_plus(db_passwd), db_host, db_port, db_name)
+    if db_type == "mysql":
+        db_url = "mysql+pymysql://%s:%s@%s:%s/%s?charset=utf8" % (db_user, quote_plus(db_passwd), db_host, db_port, db_name)
+    elif db_type == "pgsql":
+        db_url = "postgresql://%s:%s@%s:%s/%s" % (db_user, quote_plus(db_passwd), db_host, db_port, db_name)
+    else:
+        _logger.warning('Failed to init seahub db, only mysql and postgres db supported.')
+        return
 
     # Add pool recycle, or mysql connection will be closed by mysqld if idle
     # for too long.


### PR DESCRIPTION
## In Short

- [x] Validate and test the changes
- [x] Ensure postgres support in Seahub and Seafile-Server as well

## Related

https://github.com/haiwen/seafile-server/pull/560
https://github.com/haiwen/seahub/pull/5196

## Rationale

Many users (me included) use Seafile with PostgreSQL databases. Seafile has supported Postgres databases with small patches for many years, but during a recent db backend rewrite that functionality got removed. My own deployment has been stuck on 7.0, with no update in sight.

Due to that, I’ve decided to implement Postgres support back into Seafile. If it doesn’t get merged, I’ll have to maintain a custom fork with downstream patches, which I’d like to avoid.