### PR TITLE
Remove all locks/properties after file is deleted

### DIFF
--- a/wsgidav/seafile_dav_provider.py
+++ b/wsgidav/seafile_dav_provider.py
@@ -276,6 +276,9 @@ class SeafileResource(DAVNonCollection):
 
             parent, filename = os.path.split(self.rel_path)
             seafile_api.del_file(self.repo.id, parent, '[\"' + filename + '\"]', self.username)
+
+            self.remove_all_properties(recursive=True)
+            self.remove_all_locks(recursive=True)
         except SearpcError as e:
             raise DAVError(HTTP_INTERNAL_ERROR, e.msg)
 
@@ -532,6 +535,9 @@ class SeafDirResource(DAVCollection):
                 raise DAVError(HTTP_BAD_REQUEST)
 
             seafile_api.del_file(self.repo.id, parent, '[\"' + filename + '\"]', self.username)
+
+            self.remove_all_properties(recursive=True)
+            self.remove_all_locks(recursive=True)
         except SearpcError as e:
             raise DAVError(HTTP_INTERNAL_ERROR, e.msg)
 


### PR DESCRIPTION
This removes all locks and properties after a file is deleted. See [fs_dav_provider.py](https://github.com/haiwen/seafdav/blob/master/wsgidav/fs_dav_provider.py#L111-L112) for same logic.


https://forum.seafile.com/t/17818 should be fixed with this. If you save a file through a Mapped Network Drive on Windows and especially using Office apps (Word, Excel etc.) it seems to PUT (empty) > LOCK > DELETE > PUT (with content) > LOCK and if that second lock returns 423 LOCKED (because the previous lock was not removed after DELETE) it calls DELETE again.